### PR TITLE
Keep producing data as long as Readable.push wants more

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,13 +15,14 @@ StreamGenerators.prototype = Object.create(Readable.prototype, {constructor: {va
 
 StreamGenerators.prototype._read = function(size) {
     try {
-        var r = this._g.next();
+        do {
+            var r = this._g.next();
 
-        if (false === r.done) {
-            this.push(r.value);
-        } else {
-            this.push(null);
-        }
+            if (r.done) {
+                this.push(null);
+                break;
+            }
+        } while (this.push(r.value));
     } catch (e) {
         this.emit('error', e);
     }


### PR DESCRIPTION
According to [the documentation](https://nodejs.org/api/stream.html#stream_readable_read_size_1), "`_read()` should continue reading from the resource and pushing data until push returns `false`". This pull request implements that requirement.
